### PR TITLE
Remove unnecessary declaration

### DIFF
--- a/src/polyhedron.jl
+++ b/src/polyhedron.jl
@@ -7,7 +7,7 @@ end
 Library() = Library(nothing)
 _isone(d::Int) = isone(d)
 _isone(d::StaticArrays.Size{(1,)}) = true
-_isone(d::StaticArrays.Size) where T = false
+_isone(d::StaticArrays.Size) = false
 Polyhedra.similar_library(l::Library, d::Polyhedra.FullDim, T::Type) = Polyhedra.default_library(d, T)
 function Polyhedra.similar_library(l::Library, d::Polyhedra.FullDim, ::Type{Float64})
     if _isone(d)


### PR DESCRIPTION
Stops this message coming up:

```julia
WARNING: method definition for _isone at C:\Users\User\.julia\packages\QHull\Zm8Gl\src\polyhedron.jl:10 declares type variable T but does not use it.
```